### PR TITLE
28 speed up pipeline runtimes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,10 +66,11 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+        with:
+          cache-compiled: "true"
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
         with:
           files: lcov.info
-      

--- a/test/laplace.jl
+++ b/test/laplace.jl
@@ -395,7 +395,7 @@ end
     # WORKFLOWS
 
     # NOTE: batchsize=0 is meant to represent unbatched
-    batchsizes = [0, 1, 32]
+    batchsizes = [0, 32]
     backends = [:GGN, :EmpiricalFisher]
     subsets_of_weights = [:all, :last_layer, :subnetwork]
 


### PR DESCRIPTION
Solves #28.
- Enable precompilation caching
- Remove redundant testcase

The pipeline now completes in ~15 min instead of 20, which is a 25% speedup, matching the criteria of #28 